### PR TITLE
Fixed incorrect expected message

### DIFF
--- a/src/test/java/edu/austral/ingsis/FileSystemTests.java
+++ b/src/test/java/edu/austral/ingsis/FileSystemTests.java
@@ -43,7 +43,7 @@ public class FileSystemTests {
             entry("cd emily", "moved to directory 'emily'"),
             entry("pwd", "/emily"),
             entry("touch elizabeth.txt", "'elizabeth.txt' file created"),
-            entry("mkdir t-bone", "'t-bone' directory"),
+            entry("mkdir t-bone", "'t-bone' directory created"),
             entry("ls", "elizabeth t-bone")
     ));
   }

--- a/src/test/java/edu/austral/ingsis/FileSystemTests.java
+++ b/src/test/java/edu/austral/ingsis/FileSystemTests.java
@@ -56,7 +56,7 @@ public class FileSystemTests {
             entry("mkdir jetta", "'jetta' directory created"),
             entry("cd emily", "moved to directory 'emily'"),
             entry("touch elizabeth.txt", "'elizabeth.txt' file created"),
-            entry("mkdir t-bone", "'t-bone' directory"),
+            entry("mkdir t-bone", "'t-bone' directory created"),
             entry("touch elizabeth.txt", "'elizabeth.txt' file created"),
             entry("ls", "t-bone elizabeth.txt"),
             entry("rm", "cannot remove 't-bone', is a directory"),


### PR DESCRIPTION
mkdir is expected to return "[dirname] directory created", but for t-bone it only expects "t-bone directory"